### PR TITLE
Adds macro implementations to commonly used traits.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,6 @@ min_horizontal_size  = 5
 min_vertical_size    = 5
 max_horizontal_ratio = 0.9
 max_vertical_ratio   = 1.0
-seed                 = 665
+seed                 = 445
 min_area             = 25
 frame                = false

--- a/src/game/actors/enemy.rs
+++ b/src/game/actors/enemy.rs
@@ -8,8 +8,7 @@ use game::actors::health::Health;
 use game::actors::player::Player;
 
 pub struct Enemy {
-    pub x: i32,
-    pub y: i32,
+    pub xy: (i32, i32),
     head: i32,
     arms: (i32, i32),
     torso: i32,
@@ -21,10 +20,9 @@ pub struct Enemy {
 }
 
 impl Enemy {
-    pub fn new(x: i32, y: i32, attack_cooldown: i32, map: &Map) -> Enemy {
+    pub fn new(xy: (i32, i32) , attack_cooldown: i32, map: &Map) -> Enemy {
         return Enemy {
-            x,
-            y,
+            xy,
             head: 100,
             arms: (100, 100),
             torso: 100,
@@ -56,7 +54,8 @@ impl Enemy {
     }
 
     pub fn clear(&self, mut window: &Root) {
-        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
+        let (x, y) = self.xy;
+        window.put_char(x, y, ' ', BackgroundFlag::Set);
     }
 
     fn recalculate_dijkstra(&mut self, destination: (i32, i32)) {
@@ -126,12 +125,11 @@ impl Health for Enemy {
 
 impl GameObject for Enemy {
     fn get_position(&self) -> (i32, i32) {
-        (self.x, self.y)
+        self.xy
     }
 
-    fn set_position(&mut self, position: (i32, i32)) {
-        self.x = position.0;
-        self.y = position.1;
+    fn set_position(&mut self, xy: (i32, i32)) {
+        self.xy = xy;
     }
 
     fn get_symbol(&self) -> char { 'E' }

--- a/src/game/actors/enemy.rs
+++ b/src/game/actors/enemy.rs
@@ -10,9 +10,9 @@ use game::actors::player::Player;
 pub struct Enemy {
     pub xy: (i32, i32),
     head: i32,
-    arms: (i32, i32),
+    arms: Vec<i32>,
     torso: i32,
-    legs: (i32, i32),
+    legs: Vec<i32>,
     attack_cooldown: i32,
     attack_time: i32, // The number of frames in between each attack
     map: Dijkstra<'static>,
@@ -25,9 +25,9 @@ impl Enemy {
         return Enemy {
             xy,
             head: 100,
-            arms: (100, 100),
+            arms: vec![100, 100],
             torso: 100,
-            legs: (100, 100),
+            legs: vec![100, 100],
             attack_cooldown,
             attack_time: 0,
             map: Dijkstra::new_from_map(map.clone(), 0_f32),
@@ -67,62 +67,6 @@ impl Enemy {
     }
 }
 
-impl Health for Enemy {
-    fn get_head(&self) -> i32 {
-        self.head
-    }
-
-    fn get_arms(&self) -> Vec<i32> {
-        vec![self.arms.0, self.arms.1]
-    }
-
-    fn get_torso(&self) -> i32 {
-        self.torso
-    }
-
-    fn get_legs(&self) -> Vec<i32> {
-        vec![self.legs.0, self.legs.1]
-    }
-
-    fn set_head(&mut self, value: i32) {
-        self.head = value;
-    }
-
-    fn set_arms(&mut self, value: Vec<i32>) -> Result<Vec<i32>, io::Error> {
-        if value.len() < 2 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Error setting arm health for enemy. This enemy has two arms.",
-            ));
-        }
-
-        self.arms.0 = value[0];
-        self.arms.1 = value[1];
-
-        Ok(value)
-    }
-
-    fn set_torso(&mut self, value: i32) {
-        self.torso = value;
-    }
-
-    fn set_legs(&mut self, value: Vec<i32>) -> Result<Vec<i32>, io::Error> {
-        if value.len() < 2 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Error setting leg health for enemy. This enemy has two legs.",
-            ));
-        }
-
-        self.legs.0 = value[0];
-        self.legs.1 = value[1];
-
-        Ok(value)
-    }
-
-    fn is_dead(&self) -> bool {
-        return !(self.head > 0 && self.torso > 0);
-    }
-}
+implement_health!(Enemy);
 
 implement_gameobject!(Enemy);

--- a/src/game/actors/enemy.rs
+++ b/src/game/actors/enemy.rs
@@ -8,7 +8,8 @@ use game::actors::health::Health;
 use game::actors::player::Player;
 
 pub struct Enemy {
-    pub xy: (i32, i32),
+    pub x: i32,
+    pub y: i32,
     head: i32,
     arms: Vec<i32>,
     torso: i32,
@@ -21,9 +22,10 @@ pub struct Enemy {
 }
 
 impl Enemy {
-    pub fn new(xy: (i32, i32) , attack_cooldown: i32, map: &Map) -> Enemy {
+    pub fn new(x: i32, y: i32, attack_cooldown: i32, map: &Map) -> Enemy {
         return Enemy {
-            xy,
+            x,
+            y,
             head: 100,
             arms: vec![100, 100],
             torso: 100,
@@ -38,7 +40,8 @@ impl Enemy {
 
     pub fn update(&mut self, player: &mut Player, recalculate: bool) {
         if recalculate == true {
-            self.recalculate_dijkstra(player.get_position());
+            let (x, y) = player.get_position();
+            self.recalculate_dijkstra(x, y);
         }
         
         // When attack_time reaches attack_cooldown, the enemy can attack
@@ -49,21 +52,20 @@ impl Enemy {
             player.calculate_damage(self.damage);
             self.attack_time = 0;
         }
-        else if let Some(position) = self.map.walk_one_step() {
-            self.set_position(position);
+        else if let Some((x, y)) = self.map.walk_one_step() {
+            self.set_position(x, y);
             self.attack_time = 0;
         }
     }
 
     pub fn clear(&self, mut window: &Root) {
-        let (x, y) = self.xy;
-        window.put_char(x, y, ' ', BackgroundFlag::Set);
+        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
     }
 
-    fn recalculate_dijkstra(&mut self, destination: (i32, i32)) {
+    fn recalculate_dijkstra(&mut self, x: i32, y: i32) {
         let root = self.get_position();
         self.map.compute_grid(root);
-        self.map.find(destination);
+        self.map.find((x, y));
     }
 }
 

--- a/src/game/actors/enemy.rs
+++ b/src/game/actors/enemy.rs
@@ -16,7 +16,8 @@ pub struct Enemy {
     attack_cooldown: i32,
     attack_time: i32, // The number of frames in between each attack
     map: Dijkstra<'static>,
-    damage: i32
+    damage: i32,
+    symbol: char,
 }
 
 impl Enemy {
@@ -30,7 +31,8 @@ impl Enemy {
             attack_cooldown,
             attack_time: 0,
             map: Dijkstra::new_from_map(map.clone(), 0_f32),
-            damage: 15
+            damage: 15,
+            symbol: 'E',
         };
     }
 
@@ -123,14 +125,4 @@ impl Health for Enemy {
     }
 }
 
-impl GameObject for Enemy {
-    fn get_position(&self) -> (i32, i32) {
-        self.xy
-    }
-
-    fn set_position(&mut self, xy: (i32, i32)) {
-        self.xy = xy;
-    }
-
-    fn get_symbol(&self) -> char { 'E' }
-}
+implement_gameobject!(Enemy);

--- a/src/game/actors/game_object.rs
+++ b/src/game/actors/game_object.rs
@@ -6,7 +6,7 @@ use game::map::tile::Tile;
 pub trait GameObject {
     fn get_position(&self) -> (i32, i32);
 
-    fn set_position(&mut self, position: (i32, i32));
+    fn set_position(&mut self, xy: (i32, i32));
 
     fn get_symbol(&self) -> char;
 
@@ -40,4 +40,24 @@ pub trait GameObject {
 
         return (x2 <= x1 + 1) && (x2 >= x1 - 1) && (y2 <= y1 + 1) && (y2 >= y1 - 1) 
     }
+}
+
+
+macro_rules! implement_gameobject {
+    ($type:ty) => {
+        impl GameObject for $type {
+            fn get_position(&self) -> (i32, i32) {
+                return self.xy;
+            }
+
+            fn set_position(&mut self, xy: (i32, i32)) {
+                self.xy = xy;
+            }
+
+            fn get_symbol(&self) -> char {
+                self.symbol
+            }
+        }
+        
+    };
 }

--- a/src/game/actors/game_object.rs
+++ b/src/game/actors/game_object.rs
@@ -33,8 +33,7 @@ pub trait GameObject {
         Ok(true)
     }
 
-    fn is_adjacent_to<T>(&self, other: &T) -> bool
-        where T: GameObject
+    fn is_adjacent_to(&self, other: &GameObject) -> bool
     {
         let (x1, y1) = self.get_position();
         let (x2, y2) = other.get_position();

--- a/src/game/actors/game_object.rs
+++ b/src/game/actors/game_object.rs
@@ -23,8 +23,7 @@ pub trait GameObject {
         }
 
         for tile in tiles {
-            if tile.get_x() == proposed_x &&
-            tile.get_y() == proposed_y &&
+            if tile.get_xy() == position &&
             tile.get_walkable() == false {
                 return Ok(false);
             }

--- a/src/game/actors/game_object.rs
+++ b/src/game/actors/game_object.rs
@@ -6,7 +6,7 @@ use game::map::tile::Tile;
 pub trait GameObject {
     fn get_position(&self) -> (i32, i32);
 
-    fn set_position(&mut self, xy: (i32, i32));
+    fn set_position(&mut self, x: i32, y: i32);
 
     fn get_symbol(&self) -> char;
 
@@ -15,21 +15,20 @@ pub trait GameObject {
         window.put_char(x, y, self.get_symbol(), BackgroundFlag::Set);
     }
 
-    fn move_object(&mut self, tiles: &Vec<Box<Tile>>, position: (i32, i32)) -> Result<bool, io::Error> {
-        let (x, y) = self.get_position();
-        let (proposed_x, proposed_y) = position;
-        if (x - proposed_x).abs() > 1 || (y - proposed_y).abs() > 1 {
+    fn move_object(&mut self, tiles: &Vec<Box<Tile>>, x: i32, y: i32) -> Result<bool, io::Error> {
+        let (self_x, self_y) = self.get_position();
+        if (self_x - x).abs() > 1 || (self_y - y).abs() > 1 {
             return Err(io::Error::new(io::ErrorKind::InvalidInput, "Cannot move an object further than an adjacent tile, try using set_position instead."));
         }
 
         for tile in tiles {
-            if tile.get_xy() == position &&
+            if tile.get_position() == (x, y) &&
             tile.get_walkable() == false {
                 return Ok(false);
             }
         }
 
-        self.set_position(position);
+        self.set_position(x, y);
         Ok(true)
     }
 
@@ -47,11 +46,12 @@ macro_rules! implement_gameobject {
     ($type:ty) => {
         impl GameObject for $type {
             fn get_position(&self) -> (i32, i32) {
-                return self.xy;
+                return (self.x, self.y);
             }
 
-            fn set_position(&mut self, xy: (i32, i32)) {
-                self.xy = xy;
+            fn set_position(&mut self, x: i32, y: i32) {
+                self.x = x;
+                self.y = y;
             }
 
             fn get_symbol(&self) -> char {

--- a/src/game/actors/health.rs
+++ b/src/game/actors/health.rs
@@ -111,3 +111,61 @@ pub fn draw_health_bar<T>(object: &T, mut window: &Root)
         }
     }
 }
+
+macro_rules! implement_health {
+    ($type:ty) => {
+        impl Health for $type {
+            fn get_head(&self) -> i32 {
+                self.head
+            }
+
+            fn get_arms(&self) -> Vec<i32> {
+                self.arms.clone()
+            }
+
+            fn get_torso(&self) -> i32 {
+                self.torso
+            }
+
+            fn get_legs(&self) -> Vec<i32> {
+                self.legs.clone()
+            }
+
+            fn set_head(&mut self, value: i32) {
+                self.head = value;
+            }
+
+            fn set_arms(&mut self, value: Vec<i32>) -> Result<Vec<i32>, io::Error>{
+                if value.len() != self.arms.len() {
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, format!("Error setting arm health. Expected {} values found {}", self.arms.len(), value.len())));
+                }
+
+                for i in 0..value.len() {
+                    self.arms[i] = value[i];
+                }
+
+                Ok(value)
+            }
+
+            fn set_torso(&mut self, value: i32) {
+                self.torso = value;
+            }
+
+            fn set_legs(&mut self, value: Vec<i32>) -> Result<Vec<i32>, io::Error> {
+                if value.len() != self.legs.len() {
+                    return Err(io::Error::new(io::ErrorKind::InvalidData, format!("Error setting leg health. Expected {} values found {}", self.legs.len(), value.len())));
+                }
+
+                for i in 0..value.len() {
+                    self.legs[i] = value[i];
+                }
+
+                Ok(value)
+            }
+
+            fn is_dead(&self) -> bool {
+                return !(self.head > 0 && self.torso > 0);
+            }
+        }
+    };
+}

--- a/src/game/actors/mod.rs
+++ b/src/game/actors/mod.rs
@@ -1,4 +1,5 @@
+#[macro_use]
+pub mod game_object;
 pub mod player;
 pub mod health;
-pub mod game_object;
 pub mod enemy;

--- a/src/game/actors/mod.rs
+++ b/src/game/actors/mod.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 pub mod game_object;
-pub mod player;
+#[macro_use]
 pub mod health;
+pub mod player;
 pub mod enemy;

--- a/src/game/actors/player.rs
+++ b/src/game/actors/player.rs
@@ -9,8 +9,7 @@ use game::actors::game_object;
 
 #[derive(Debug, Clone)]
 pub struct Player {
-    pub x: i32,
-    pub y: i32,
+    pub xy: (i32, i32),
     head: i32,
     arms: (i32, i32),
     torso: i32,
@@ -18,10 +17,9 @@ pub struct Player {
 }
 
 impl Player {
-    pub fn new(x: i32, y: i32) -> Player {
+    pub fn new(xy: (i32, i32)) -> Player {
         return Player {
-            x, 
-            y,
+            xy,
             head: 100,
             arms: (100, 100),
             torso: 100,
@@ -51,7 +49,8 @@ impl Player {
             _ => {},
         }
 
-        let proposed_position = (self.x + proposed_x, self.y + proposed_y);
+        let (x, y) = self.xy;
+        let proposed_position = (x + proposed_x, y + proposed_y);
         game_object::GameObject::move_object(self, tiles, proposed_position).unwrap()
     }
 
@@ -84,7 +83,7 @@ impl Player {
     }
 
     pub fn clear(&self, mut window: &Root) {
-        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
+        window.put_char(self.xy.0, self.xy.1, ' ', BackgroundFlag::Set);
     }
 }
 
@@ -142,12 +141,11 @@ impl health::Health for Player {
 
 impl game_object::GameObject for Player {
     fn get_position(&self) -> (i32, i32) {
-        (self.x, self.y)
+        self.xy
     }
 
-    fn set_position(&mut self, position: (i32, i32)) {
-        self.x = position.0;
-        self.y = position.1;
+    fn set_position(&mut self, xy: (i32, i32)) {
+        self.xy = xy;
     }
 
     fn get_symbol(&self) -> char { '@' }

--- a/src/game/actors/player.rs
+++ b/src/game/actors/player.rs
@@ -5,7 +5,7 @@ use std::io;
 
 use game::map::tile::Tile;
 use game::actors::health;
-use game::actors::game_object;
+use game::actors::game_object::GameObject;
 
 #[derive(Debug, Clone)]
 pub struct Player {
@@ -13,7 +13,8 @@ pub struct Player {
     head: i32,
     arms: (i32, i32),
     torso: i32,
-    legs: (i32, i32)
+    legs: (i32, i32),
+    symbol: char
 }
 
 impl Player {
@@ -23,7 +24,8 @@ impl Player {
             head: 100,
             arms: (100, 100),
             torso: 100,
-            legs: (100, 100)
+            legs: (100, 100),
+            symbol: '@',
         };
     }
 
@@ -51,7 +53,7 @@ impl Player {
 
         let (x, y) = self.xy;
         let proposed_position = (x + proposed_x, y + proposed_y);
-        game_object::GameObject::move_object(self, tiles, proposed_position).unwrap()
+        GameObject::move_object(self, tiles, proposed_position).unwrap()
     }
 
     pub fn draw_hud(&self, window: &Root) {
@@ -139,14 +141,4 @@ impl health::Health for Player {
     }
 }
 
-impl game_object::GameObject for Player {
-    fn get_position(&self) -> (i32, i32) {
-        self.xy
-    }
-
-    fn set_position(&mut self, xy: (i32, i32)) {
-        self.xy = xy;
-    }
-
-    fn get_symbol(&self) -> char { '@' }
-}
+implement_gameobject!(Player);

--- a/src/game/actors/player.rs
+++ b/src/game/actors/player.rs
@@ -4,16 +4,16 @@ use tcod::colors;
 use std::io;
 
 use game::map::tile::Tile;
-use game::actors::health;
+use game::actors::health::Health;
 use game::actors::game_object::GameObject;
 
 #[derive(Debug, Clone)]
 pub struct Player {
     pub xy: (i32, i32),
     head: i32,
-    arms: (i32, i32),
+    arms: Vec<i32>,
     torso: i32,
-    legs: (i32, i32),
+    legs: Vec<i32>,
     symbol: char
 }
 
@@ -22,9 +22,9 @@ impl Player {
         return Player {
             xy,
             head: 100,
-            arms: (100, 100),
+            arms: vec![100, 100],
             torso: 100,
-            legs: (100, 100),
+            legs: vec![100, 100],
             symbol: '@',
         };
     }
@@ -58,11 +58,11 @@ impl Player {
 
     pub fn draw_hud(&self, window: &Root) {
         self.draw_health(self.head, "H ", 0, window);
-        self.draw_health(self.arms.0, "AL", 1, window);
-        self.draw_health(self.arms.1, "AR", 2, window);
+        self.draw_health(self.arms[0], "AL", 1, window);
+        self.draw_health(self.arms[1], "AR", 2, window);
         self.draw_health(self.torso, "T ", 3, window);
-        self.draw_health(self.legs.0, "LL", 4, window);
-        self.draw_health(self.legs.1, "LR", 5, window);
+        self.draw_health(self.legs[0], "LL", 4, window);
+        self.draw_health(self.legs[1], "LR", 5, window);
     }
 
     fn draw_health(&self, health: i32, label: &str, row: i32, mut window: &Root) {
@@ -89,56 +89,6 @@ impl Player {
     }
 }
 
-impl health::Health for Player {
-    fn get_head(&self) -> i32 {
-        self.head
-    }
-
-    fn get_arms(&self) -> Vec<i32> {
-        vec![self.arms.0, self.arms.1]
-    }
-
-    fn get_torso(&self) -> i32 {
-        self.torso
-    }
-
-    fn get_legs(&self) -> Vec<i32> {
-        vec![self.legs.0, self.legs.1]
-    }
-
-    fn set_head(&mut self, value: i32) {
-        self.head = value;
-    }
-
-    fn set_arms(&mut self, value: Vec<i32>) -> Result<Vec<i32>, io::Error>{
-        if value.len() < 2 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "Error setting arm health for player, players require at least 2 arm health values to be provided."));
-        }
-
-        self.arms.0 = value[0];
-        self.arms.1 = value[1];
-
-        Ok(value)
-    }
-
-    fn set_torso(&mut self, value: i32) {
-        self.torso = value;
-    }
-
-    fn set_legs(&mut self, value: Vec<i32>) -> Result<Vec<i32>, io::Error> {
-        if value.len() < 2 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "Error setting leg health for player, players require at least 2 leg health values to be provided."));
-        }
-
-        self.legs.0 = value[0];
-        self.legs.1 = value[1];
-
-        Ok(value)
-    }
-
-    fn is_dead(&self) -> bool {
-        return !(self.head > 0 && self.torso > 0);
-    }
-}
+implement_health!(Player);
 
 implement_gameobject!(Player);

--- a/src/game/actors/player.rs
+++ b/src/game/actors/player.rs
@@ -9,7 +9,8 @@ use game::actors::game_object::GameObject;
 
 #[derive(Debug, Clone)]
 pub struct Player {
-    pub xy: (i32, i32),
+    pub x: i32,
+    pub y: i32,
     head: i32,
     arms: Vec<i32>,
     torso: i32,
@@ -18,9 +19,10 @@ pub struct Player {
 }
 
 impl Player {
-    pub fn new(xy: (i32, i32)) -> Player {
+    pub fn new(x: i32, y: i32) -> Player {
         return Player {
-            xy,
+            x,
+            y,
             head: 100,
             arms: vec![100, 100],
             torso: 100,
@@ -51,9 +53,9 @@ impl Player {
             _ => {},
         }
 
-        let (x, y) = self.xy;
-        let proposed_position = (x + proposed_x, y + proposed_y);
-        GameObject::move_object(self, tiles, proposed_position).unwrap()
+        let x = self.x;
+        let y = self.y;
+        GameObject::move_object(self, tiles, x + proposed_x, y + proposed_y).unwrap()
     }
 
     pub fn draw_hud(&self, window: &Root) {
@@ -85,7 +87,7 @@ impl Player {
     }
 
     pub fn clear(&self, mut window: &Root) {
-        window.put_char(self.xy.0, self.xy.1, ' ', BackgroundFlag::Set);
+        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
     }
 }
 

--- a/src/game/map/mapgen.rs
+++ b/src/game/map/mapgen.rs
@@ -13,26 +13,28 @@ struct Map {
 */
 
 pub struct Room {
-    xy: (i32, i32),
-    wh: (i32, i32),
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
     walls: Vec<Line>
 }
 
-fn create_tile((w, h): (i32, i32), (map_width, map_height): (i32, i32)) -> Box<Tile> {
+fn create_tile(w: i32, h: i32, map_width: i32, map_height: i32) -> Box<Tile> {
     if w == 0 || w == map_width-1 || h == 0 || h == map_height-1 || (w % 3 == 1 && h % 2 == 1) {
-        Box::new(Wall::new((w, h)))
+        Box::new(Wall::new(w, h))
     } else {
-        Box::new(Floor::new((w, h)))
+        Box::new(Floor::new(w, h))
     }
 }
 
-pub fn dummy_gen((map_w, map_h): (i32, i32)) -> (Map, Vec<Box<Tile>>) {
+pub fn dummy_gen(map_w: i32, map_h: i32) -> (Map, Vec<Box<Tile>>) {
     let mut tiles: Vec<Box<Tile>> = Vec::new();
     let mut map = Map::new(map_w, map_h);
 
     for h in 0..map_w {
         for w in 0..map_h {
-            let tile = create_tile((w, h), (map_w, map_h));
+            let tile = create_tile(w, h, map_w, map_h);
 
             map.set(w, h, tile.get_see_through(), tile.get_walkable());
             tiles.push(tile);
@@ -42,48 +44,50 @@ pub fn dummy_gen((map_w, map_h): (i32, i32)) -> (Map, Vec<Box<Tile>>) {
     return (map, tiles);
 }
 
-pub fn empty_gen((map_width, map_height): (i32, i32)) -> (Map, Vec<Box<Tile>>) {
+pub fn empty_gen(map_width: i32, map_height: i32) -> (Map, Vec<Box<Tile>>) {
     let mut tiles: Vec<Box<Tile>> = Vec::new();
     let mut map = Map::new(map_width, map_height);
 
     for h in 0..map_height {
         for w in 0..map_width {
-            new_floor(&mut map, &mut tiles, (w, h));
+            new_floor(&mut map, &mut tiles, w, h);
         }
     }
-    draw_box(&mut map, &mut tiles, (0, 0), (map_width - 1, map_height - 1));
+    draw_box(&mut map, &mut tiles, 0, 0, map_width - 1, map_height - 1);
 
     return (map, tiles);
 }
 
-fn new_floor(map: &mut Map, tiles: &mut Vec<Box<Tile>>, xy: (i32, i32)) {
-    let tile = Box::new(Floor::new(xy));
-    map.set(xy.0, xy.1, tile.get_see_through(), tile.get_walkable());
+fn new_floor(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32) {
+    let tile = Box::new(Floor::new(x, y));
+    map.set(x, y, tile.get_see_through(), tile.get_walkable());
     tiles.push(tile);
 }
 
-fn new_wall(map: &mut Map, tiles: &mut Vec<Box<Tile>>, xy: (i32, i32)) {
-    let tile = Box::new(Wall::new(xy));
+fn new_wall(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32) {
+    let tile = Box::new(Wall::new(x, y));
     let see_through = if CONFIG.game.see_all { true } else { tile.get_see_through() };
-    map.set(xy.0, xy.1, see_through, tile.get_walkable());
+    map.set(x, y, see_through, tile.get_walkable());
     tiles.push(tile);
 }
 
-fn draw_box(map: &mut Map, tiles: &mut Vec<Box<Tile>>, (x, y): (i32, i32), (w, h): (i32, i32)) {
+fn draw_box(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32, w: i32, h: i32) {
     for i in x..w {
-        new_wall(map, tiles, (i, y));
-        new_wall(map, tiles, (i, h));
+        new_wall(map, tiles, i, y);
+        new_wall(map, tiles, i, h);
     }
     for i in y..h {
-        new_wall(map, tiles, (x, i));
-        new_wall(map, tiles, (w, i));
+        new_wall(map, tiles, x, i);
+        new_wall(map, tiles, w, i);
     }
-    new_wall(&mut *map, &mut *tiles, (w, h));
+    new_wall(&mut *map, &mut *tiles, w, h);
 }
 
 fn gen_room(room: &Room, rng: &Rng, frame: bool, min_area: i32) -> Option<Room> {
-    let (x, y) = room.xy;
-    let (w, h) = room.wh;
+    let x = room.x;
+    let y = room.y;
+    let w = room.w;
+    let h = room.h;
 
     if w * h < min_area {
        return None;
@@ -125,10 +129,10 @@ fn gen_room(room: &Room, rng: &Rng, frame: bool, min_area: i32) -> Option<Room> 
        '═' 186
     //═║╔╗╚╝
     */
-    return Some(Room {xy: (x1, y1), wh: (x2 - x1, y2 - y1), walls: Vec::new()});
+    return Some(Room {x: x1, y: y1, w: x2 - x1, h: y2 - y1, walls: Vec::new()});
 }
 
-pub fn get_walls((x, y): (i32, i32), (w, h): (i32, i32)) -> Vec<((i32, i32), (i32, i32))> {
+pub fn get_walls(x: i32, y: i32, w: i32, h: i32) -> Vec<((i32, i32), (i32, i32))> {
     vec![
         ((x,y),(x + w, y)),
         ((x,y),(x, y + h)),
@@ -139,8 +143,8 @@ pub fn get_walls((x, y): (i32, i32), (w, h): (i32, i32)) -> Vec<((i32, i32), (i3
 
 fn within_another_room(wall: (i32, i32), rooms: &Vec<Room>) -> bool {
     for room in rooms {
-        if wall.0 > room.xy.0 && wall.0 < (room.xy.0 + room.wh.0) &&
-           wall.1 > room.xy.1 && wall.1 < (room.xy.1 + room.wh.1) {
+        if wall.0 > room.x && wall.0 < (room.x + room.w) &&
+           wall.1 > room.y && wall.1 < (room.y + room.h) {
             return true;
         }
     }
@@ -154,16 +158,16 @@ pub fn add_to_map(rooms: Vec<Room>, m: Map, t: Vec<Box<Tile>>) -> (Map, Vec<Box<
 
     for room in &rooms {
 
-        if !within_another_room(room.xy, &rooms) {
-            new_wall(&mut map, &mut tiles, room.xy);
+        if !within_another_room((room.x, room.y), &rooms) {
+            new_wall(&mut map, &mut tiles, room.x, room.y);
         }
 
-        for wall in get_walls(room.xy, room.wh) {
+        for wall in get_walls(room.x, room.y, room.w, room.h) {
             let mut line = Line::new(wall.0, wall.1);
 
-            while let Some(w) = line.step() {
-                if !within_another_room(w, &rooms) {
-                    new_wall(&mut map, &mut tiles, w)
+            while let Some((w, h)) = line.step() {
+                if !within_another_room((w, h), &rooms) {
+                    new_wall(&mut map, &mut tiles, w, h)
                 }
             }
         }
@@ -172,8 +176,8 @@ pub fn add_to_map(rooms: Vec<Room>, m: Map, t: Vec<Box<Tile>>) -> (Map, Vec<Box<
 }
 
 fn generate_connecting_hallway(r1: &Room, r2: &Room) -> (Room, Room) {
-    let center_r1: (i32, i32) = (r1.xy.0 + r1.wh.0/2, r1.xy.1 + r1.wh.1/2);
-    let center_r2: (i32, i32) = (r2.xy.0 + r2.wh.0/2, r2.xy.1 + r2.wh.1/2);
+    let center_r1: (i32, i32) = (r1.x + r1.w/2, r1.y + r1.h/2);
+    let center_r2: (i32, i32) = (r2.x + r2.w/2, r2.y + r2.h/2);
     let center_delta: (i32, i32) = (center_r2.0 - center_r1.0, center_r2.1 - center_r1.1);
 
     let hallway_horiz_xy = if center_delta.0 >= 0 {
@@ -189,14 +193,18 @@ fn generate_connecting_hallway(r1: &Room, r2: &Room) -> (Room, Room) {
     };
 
     let hallway_horizontal = Room {
-        xy: hallway_horiz_xy,
-        wh: (center_delta.0.abs() + 1, 2),
+        x: hallway_horiz_xy.0,
+        y: hallway_horiz_xy.1,
+        w: center_delta.0.abs() + 1,
+        h: 2,
         walls: Vec::new()
     };
 
     let hallway_vertical = Room {
-        xy: hallway_vert_xy,
-        wh: (2, center_delta.1.abs() + 1),
+        x: hallway_vert_xy.0,
+        y: hallway_vert_xy.1,
+        w: 2,
+        h: center_delta.1.abs() + 1,
         walls: Vec::new()
     };
 
@@ -208,24 +216,17 @@ pub fn generate_rooms(frames: &Vec<Room>) -> Vec<Room> {
     let mut rooms: Vec<Room> = Vec::new();
     let mut hallways: Vec<Room> = Vec::new();
 
-    let mut prev_room = 0;
-    let mut curr_room = 1;
-    let mut rooms_len = 0;
-
     for frame in frames {
         if let Some(r) = gen_room(frame, &rng, CONFIG.bsp.frame, CONFIG.bsp.min_area) {
 
             rooms.push(r);
-            rooms_len += 1;
+            let room_len = rooms.len();
 
-            if rooms_len >= 2 {
-                let hallway = generate_connecting_hallway(&rooms[prev_room], &rooms[curr_room]);
+            if room_len >= 2 {
+                let hallway = generate_connecting_hallway(&rooms[room_len - 1], &rooms[room_len - 2]);
 
                 hallways.push(hallway.0);
                 hallways.push(hallway.1);
-
-                prev_room += 1;
-                curr_room += 1;
             }
         }
     };
@@ -247,8 +248,10 @@ pub fn generate_frames() -> Vec<Room> {
         if node.is_leaf() {
             frames.push(
                 Room {
-                    xy: (node.x, node.y),
-                    wh: (node.w, node.h),
+                    x: node.x,
+                    y: node.y,
+                    w: node.w,
+                    h: node.h,
                     walls: Vec::new(),
                 }
             );
@@ -260,7 +263,7 @@ pub fn generate_frames() -> Vec<Room> {
 
 //single_room(&mut ret.0, &mut ret.1, node.x, node.y, node.w, node.h, &rng, CONFIG.bsp.frame, CONFIG.bsp.min_area);
 pub fn bsp_gen() -> (Map, Vec<Box<Tile>>) {
-    let mut map: (Map, Vec<Box<Tile>>) = empty_gen((CONFIG.game.screen_width, CONFIG.game.screen_height));
+    let mut map: (Map, Vec<Box<Tile>>) = empty_gen(CONFIG.game.screen_width, CONFIG.game.screen_height);
 
     let frames = generate_frames();
     let rooms  = generate_rooms(&frames);

--- a/src/game/map/mapgen.rs
+++ b/src/game/map/mapgen.rs
@@ -252,11 +252,7 @@ pub fn generate_rooms(frames: &Vec<Room>, seed: u32) -> Vec<Room> {
     let mut rooms: Vec<Room> = Vec::new();
     let mut hallways: Vec<Room> = Vec::new();
 
-    let mut player_spawn = (0, 0);
-
     for frame in frames.iter() {
-        let mut room_type = RoomType::Normal;
-
         if let Some(mut r) = gen_room(frame, &rng, CONFIG.bsp.min_area) {
             r.room_type = RoomType::Normal;
             rooms.push(r);

--- a/src/game/map/mapgen.rs
+++ b/src/game/map/mapgen.rs
@@ -22,9 +22,9 @@ pub struct Room {
 
 fn create_tile(w: i32, h: i32, map_width: i32, map_height: i32) -> Box<Tile> {
     if w == 0 || w == map_width-1 || h == 0 || h == map_height-1 || (w % 3 == 1 && h % 2 == 1) {
-        Box::new(Wall::new(w, h))
+        Box::new(Wall::new((w, h)))
     } else {
-        Box::new(Floor::new(w, h))
+        Box::new(Floor::new((w, h)))
     }
 }
 
@@ -59,13 +59,13 @@ pub fn empty_gen(map_width: i32, map_height: i32) -> (Map, Vec<Box<Tile>>) {
 }
 
 fn new_floor(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32) {
-    let tile = Box::new(Floor::new(x, y));
+    let tile = Box::new(Floor::new((x, y)));
     map.set(x, y, tile.get_see_through(), tile.get_walkable());
     tiles.push(tile);
 }
 
 fn new_wall(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32) {
-    let tile = Box::new(Wall::new(x, y));
+    let tile = Box::new(Wall::new((x, y)));
     let see_through = if CONFIG.game.see_all { true } else { tile.get_see_through() };
     map.set(x, y, see_through, tile.get_walkable());
     tiles.push(tile);

--- a/src/game/map/mapgen.rs
+++ b/src/game/map/mapgen.rs
@@ -13,14 +13,12 @@ struct Map {
 */
 
 pub struct Room {
-    x: i32,
-    y: i32,
-    w: i32,
-    h: i32,
+    xy: (i32, i32),
+    wh: (i32, i32),
     walls: Vec<Line>
 }
 
-fn create_tile(w: i32, h: i32, map_width: i32, map_height: i32) -> Box<Tile> {
+fn create_tile((w, h): (i32, i32), (map_width, map_height): (i32, i32)) -> Box<Tile> {
     if w == 0 || w == map_width-1 || h == 0 || h == map_height-1 || (w % 3 == 1 && h % 2 == 1) {
         Box::new(Wall::new((w, h)))
     } else {
@@ -28,13 +26,13 @@ fn create_tile(w: i32, h: i32, map_width: i32, map_height: i32) -> Box<Tile> {
     }
 }
 
-pub fn dummy_gen(map_width: i32, map_height: i32) -> (Map, Vec<Box<Tile>>) {
+pub fn dummy_gen((map_w, map_h): (i32, i32)) -> (Map, Vec<Box<Tile>>) {
     let mut tiles: Vec<Box<Tile>> = Vec::new();
-    let mut map = Map::new(map_width, map_height);
+    let mut map = Map::new(map_w, map_h);
 
-    for h in 0..map_height {
-        for w in 0..map_width {
-            let tile = create_tile(w, h, map_width, map_height);
+    for h in 0..map_w {
+        for w in 0..map_h {
+            let tile = create_tile((w, h), (map_w, map_h));
 
             map.set(w, h, tile.get_see_through(), tile.get_walkable());
             tiles.push(tile);
@@ -44,52 +42,50 @@ pub fn dummy_gen(map_width: i32, map_height: i32) -> (Map, Vec<Box<Tile>>) {
     return (map, tiles);
 }
 
-pub fn empty_gen(map_width: i32, map_height: i32) -> (Map, Vec<Box<Tile>>) {
+pub fn empty_gen((map_width, map_height): (i32, i32)) -> (Map, Vec<Box<Tile>>) {
     let mut tiles: Vec<Box<Tile>> = Vec::new();
     let mut map = Map::new(map_width, map_height);
 
     for h in 0..map_height {
         for w in 0..map_width {
-            new_floor(&mut map, &mut tiles, w, h);
+            new_floor(&mut map, &mut tiles, (w, h));
         }
     }
-    draw_box(&mut map, &mut tiles, 0, 0, map_width - 1, map_height - 1);
+    draw_box(&mut map, &mut tiles, (0, 0), (map_width - 1, map_height - 1));
 
     return (map, tiles);
 }
 
-fn new_floor(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32) {
-    let tile = Box::new(Floor::new((x, y)));
-    map.set(x, y, tile.get_see_through(), tile.get_walkable());
+fn new_floor(map: &mut Map, tiles: &mut Vec<Box<Tile>>, xy: (i32, i32)) {
+    let tile = Box::new(Floor::new(xy));
+    map.set(xy.0, xy.1, tile.get_see_through(), tile.get_walkable());
     tiles.push(tile);
 }
 
-fn new_wall(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32) {
-    let tile = Box::new(Wall::new((x, y)));
+fn new_wall(map: &mut Map, tiles: &mut Vec<Box<Tile>>, xy: (i32, i32)) {
+    let tile = Box::new(Wall::new(xy));
     let see_through = if CONFIG.game.see_all { true } else { tile.get_see_through() };
-    map.set(x, y, see_through, tile.get_walkable());
+    map.set(xy.0, xy.1, see_through, tile.get_walkable());
     tiles.push(tile);
 }
 
-fn draw_box(map: &mut Map, tiles: &mut Vec<Box<Tile>>, x: i32, y: i32, w: i32, h: i32) {
+fn draw_box(map: &mut Map, tiles: &mut Vec<Box<Tile>>, (x, y): (i32, i32), (w, h): (i32, i32)) {
     for i in x..w {
-        new_wall(map, tiles, i, y);
-        new_wall(map, tiles, i, h);
+        new_wall(map, tiles, (i, y));
+        new_wall(map, tiles, (i, h));
     }
     for i in y..h {
-        new_wall(map, tiles, x, i);
-        new_wall(map, tiles, w, i);
+        new_wall(map, tiles, (x, i));
+        new_wall(map, tiles, (w, i));
     }
-    new_wall(&mut *map, &mut *tiles, w, h);
+    new_wall(&mut *map, &mut *tiles, (w, h));
 }
 
 fn gen_room(room: &Room, rng: &Rng, frame: bool, min_area: i32) -> Option<Room> {
-    let x = room.x;
-    let y = room.y;
-    let w = room.w;
-    let h = room.h;
+    let (x, y) = room.xy;
+    let (w, h) = room.wh;
 
-    if room.w * room.h < min_area {
+    if w * h < min_area {
        return None;
     }
 
@@ -129,10 +125,10 @@ fn gen_room(room: &Room, rng: &Rng, frame: bool, min_area: i32) -> Option<Room> 
        '═' 186
     //═║╔╗╚╝
     */
-    return Some(Room {x: x1, y: y1, w: x2 - x1, h: y2 - y1, walls: Vec::new()});
+    return Some(Room {xy: (x1, y1), wh: (x2 - x1, y2 - y1), walls: Vec::new()});
 }
 
-pub fn get_walls(x: i32,y: i32,w: i32,h: i32) -> Vec<((i32, i32), (i32, i32))> {
+pub fn get_walls((x, y): (i32, i32), (w, h): (i32, i32)) -> Vec<((i32, i32), (i32, i32))> {
     vec![
         ((x,y),(x + w, y)),
         ((x,y),(x, y + h)),
@@ -143,8 +139,8 @@ pub fn get_walls(x: i32,y: i32,w: i32,h: i32) -> Vec<((i32, i32), (i32, i32))> {
 
 fn within_another_room(wall: (i32, i32), rooms: &Vec<Room>) -> bool {
     for room in rooms {
-        if wall.0 > room.x && wall.0 < (room.x + room.w) &&
-           wall.1 > room.y && wall.1 < (room.y + room.h) {
+        if wall.0 > room.xy.0 && wall.0 < (room.xy.0 + room.wh.0) &&
+           wall.1 > room.xy.1 && wall.1 < (room.xy.1 + room.wh.1) {
             return true;
         }
     }
@@ -158,16 +154,16 @@ pub fn add_to_map(rooms: Vec<Room>, m: Map, t: Vec<Box<Tile>>) -> (Map, Vec<Box<
 
     for room in &rooms {
 
-        if !within_another_room((room.x, room.y), &rooms) {
-            new_wall(&mut map, &mut tiles, room.x, room.y);
+        if !within_another_room(room.xy, &rooms) {
+            new_wall(&mut map, &mut tiles, room.xy);
         }
 
-        for wall in get_walls(room.x, room.y, room.w, room.h) {
+        for wall in get_walls(room.xy, room.wh) {
             let mut line = Line::new(wall.0, wall.1);
 
             while let Some(w) = line.step() {
-                if !within_another_room((w.0, w.1), &rooms) {
-                    new_wall(&mut map, &mut tiles, w.0, w.1)
+                if !within_another_room(w, &rooms) {
+                    new_wall(&mut map, &mut tiles, w)
                 }
             }
         }
@@ -176,8 +172,8 @@ pub fn add_to_map(rooms: Vec<Room>, m: Map, t: Vec<Box<Tile>>) -> (Map, Vec<Box<
 }
 
 fn generate_connecting_hallway(r1: &Room, r2: &Room) -> (Room, Room) {
-    let center_r1: (i32, i32) = (r1.x + r1.w/2, r1.y + r1.h/2);
-    let center_r2: (i32, i32) = (r2.x + r2.w/2, r2.y + r2.h/2);
+    let center_r1: (i32, i32) = (r1.xy.0 + r1.wh.0/2, r1.xy.1 + r1.wh.1/2);
+    let center_r2: (i32, i32) = (r2.xy.0 + r2.wh.0/2, r2.xy.1 + r2.wh.1/2);
     let center_delta: (i32, i32) = (center_r2.0 - center_r1.0, center_r2.1 - center_r1.1);
 
     let hallway_horiz_xy = if center_delta.0 >= 0 {
@@ -193,18 +189,14 @@ fn generate_connecting_hallway(r1: &Room, r2: &Room) -> (Room, Room) {
     };
 
     let hallway_horizontal = Room {
-        x: hallway_horiz_xy.0,
-        y: hallway_horiz_xy.1,
-        w: center_delta.0.abs() + 1,
-        h: 2,
+        xy: hallway_horiz_xy,
+        wh: (center_delta.0.abs() + 1, 2),
         walls: Vec::new()
     };
 
     let hallway_vertical = Room {
-        x: hallway_vert_xy.0,
-        y: hallway_vert_xy.1,
-        w: 2,
-        h: center_delta.1.abs() + 1,
+        xy: hallway_vert_xy,
+        wh: (2, center_delta.1.abs() + 1),
         walls: Vec::new()
     };
 
@@ -255,10 +247,8 @@ pub fn generate_frames() -> Vec<Room> {
         if node.is_leaf() {
             frames.push(
                 Room {
-                    x: node.x,
-                    y: node.y,
-                    w: node.w,
-                    h: node.h,
+                    xy: (node.x, node.y),
+                    wh: (node.w, node.h),
                     walls: Vec::new(),
                 }
             );
@@ -270,7 +260,7 @@ pub fn generate_frames() -> Vec<Room> {
 
 //single_room(&mut ret.0, &mut ret.1, node.x, node.y, node.w, node.h, &rng, CONFIG.bsp.frame, CONFIG.bsp.min_area);
 pub fn bsp_gen() -> (Map, Vec<Box<Tile>>) {
-    let mut map: (Map, Vec<Box<Tile>>) = empty_gen(CONFIG.game.screen_width, CONFIG.game.screen_height);
+    let mut map: (Map, Vec<Box<Tile>>) = empty_gen((CONFIG.game.screen_width, CONFIG.game.screen_height));
 
     let frames = generate_frames();
     let rooms  = generate_rooms(&frames);

--- a/src/game/map/tile.rs
+++ b/src/game/map/tile.rs
@@ -1,8 +1,8 @@
 use tcod::console::*;
 
 pub trait Tile {
-    fn new(xy: (i32, i32)) -> Self where Self: Sized;
-    fn get_xy(&self) -> (i32, i32);
+    fn new(x: i32, y: i32) -> Self where Self: Sized;
+    fn get_position(&self) -> (i32, i32);
     fn get_walkable(&self) -> bool;
     fn get_see_through(&self) -> bool;
     fn draw(&self, window: &Root);
@@ -13,14 +13,15 @@ pub trait Tile {
 macro_rules! implement_tile {
     ($type:ty) => {
         impl Tile for $type {
-            fn new(xy: (i32, i32)) -> $type {
+            fn new(x: i32, y: i32) -> $type {
                 let mut t = <$type>::default();
-                t.xy = xy;
+                t.x = x;
+                t.y = y;
                 return t;
             }
 
-            fn get_xy(&self) -> (i32, i32) {
-                return self.xy;
+            fn get_position(&self) -> (i32, i32) {
+                return (self.x, self.y);
             }
 
             fn get_walkable(&self) -> bool {
@@ -32,11 +33,11 @@ macro_rules! implement_tile {
             }
 
             fn draw(&self, mut window: &Root) {
-                window.put_char(self.xy.0, self.xy.1, self.get_symbol(), BackgroundFlag::None);
+                window.put_char(self.x, self.y, self.get_symbol(), BackgroundFlag::None);
             }
 
             fn clear(&self, mut window: &Root) {
-                window.put_char(self.xy.0, self.xy.1, ' ', BackgroundFlag::Set);
+                window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
             }
 
             fn get_symbol(&self) -> char {
@@ -47,7 +48,8 @@ macro_rules! implement_tile {
 }
 
 pub struct Wall {
-    pub xy: (i32, i32),
+    pub x: i32,
+    pub y: i32,
     pub walkable: bool,
     pub see_through: bool,
     symbol: char,
@@ -56,7 +58,8 @@ pub struct Wall {
 impl Default for Wall {
     fn default() -> Wall {
         Wall {
-            xy: (0, 0),
+            x: 0,
+            y: 0,
             walkable: false,
             see_through: false,
             symbol: '#',
@@ -67,7 +70,8 @@ impl Default for Wall {
 implement_tile!(Wall);
 
 pub struct Floor {
-    pub xy: (i32, i32),
+    pub x: i32,
+    pub y: i32,
     pub walkable: bool,
     pub see_through: bool,
     symbol: char,
@@ -76,7 +80,8 @@ pub struct Floor {
 impl Default for Floor {
     fn default() -> Floor {
         Floor {
-            xy: (0, 0),
+            x: 0,
+            y: 0,
             walkable: true,
             see_through: true,
             symbol: '.'

--- a/src/game/map/tile.rs
+++ b/src/game/map/tile.rs
@@ -1,87 +1,87 @@
 use tcod::console::*;
 
 pub trait Tile {
-    fn new(x: i32, y: i32) -> Self where Self: Sized;
-    fn get_x(&self) -> i32;
-    fn get_y(&self) -> i32;
+    fn new(xy: (i32, i32)) -> Self where Self: Sized;
+    fn get_xy(&self) -> (i32, i32);
     fn get_walkable(&self) -> bool;
     fn get_see_through(&self) -> bool;
     fn draw(&self, window: &Root);
     fn clear(&self, window: &Root);
+    fn get_symbol(&self) -> char;
 }
 
+macro_rules! implement_tile {
+    ($type:ty) => {
+        impl Tile for $type {
+            fn new(xy: (i32, i32)) -> $type {
+                let mut t = <$type>::default();
+                t.xy = xy;
+                return t;
+            }
+
+            fn get_xy(&self) -> (i32, i32) {
+                return self.xy;
+            }
+
+            fn get_walkable(&self) -> bool {
+                return self.walkable;
+            }
+
+            fn get_see_through(&self) -> bool {
+                return self.see_through;
+            }
+
+            fn draw(&self, mut window: &Root) {
+                window.put_char(self.xy.0, self.xy.1, self.get_symbol(), BackgroundFlag::None);
+            }
+
+            fn clear(&self, mut window: &Root) {
+                window.put_char(self.xy.0, self.xy.1, ' ', BackgroundFlag::Set);
+            }
+
+            fn get_symbol(&self) -> char {
+                return self.symbol;
+            }
+        }
+    };
+}
 
 pub struct Wall {
-    pub x: i32,
-    pub y: i32,
+    pub xy: (i32, i32),
     pub walkable: bool,
-    pub see_through: bool
+    pub see_through: bool,
+    symbol: char,
 }
 
-impl Tile for Wall {
-    fn new(x: i32, y: i32) -> Wall {
-        return Wall{x, y, walkable: false, see_through: false};
-    }
-
-    fn get_x(&self) -> i32 {
-        return self.x;
-    }
-
-    fn get_y(&self) -> i32 {
-        return self.y;
-    }
-
-    fn get_walkable(&self) -> bool {
-        return self.walkable;
-    }
-
-    fn get_see_through(&self) -> bool {
-        return self.see_through;
-    }
-
-    fn draw(&self, mut window: &Root) {
-        window.put_char(self.x, self.y, '#', BackgroundFlag::None);
-    }
-
-    fn clear(&self, mut window: &Root) {
-        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
+impl Default for Wall {
+    fn default() -> Wall {
+        Wall {
+            xy: (0, 0),
+            walkable: false,
+            see_through: false,
+            symbol: '#',
+        }
     }
 }
 
+implement_tile!(Wall);
 
 pub struct Floor {
-    pub x: i32,
-    pub y: i32,
+    pub xy: (i32, i32),
     pub walkable: bool,
-    pub see_through: bool
+    pub see_through: bool,
+    symbol: char,
 }
 
-impl Tile for Floor {
-    fn new(x: i32, y: i32) -> Floor {
-        return Floor{x, y, walkable: true, see_through: true};
-    }
-
-    fn get_x(&self) -> i32 {
-        return self.x;
-    }
-
-    fn get_y(&self) -> i32 {
-        return self.y;
-    }
-
-    fn get_walkable(&self) -> bool {
-        return self.walkable;
-    }
-
-    fn get_see_through(&self) -> bool {
-        return self.see_through;
-    }
-
-    fn draw(&self, mut window: &Root) {
-        window.put_char(self.x, self.y, '.', BackgroundFlag::Set);
-    }
-
-    fn clear(&self, mut window: &Root) {
-        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
+impl Default for Floor {
+    fn default() -> Floor {
+        Floor {
+            xy: (0, 0),
+            walkable: true,
+            see_through: true,
+            symbol: '.'
+        }
     }
 }
+
+implement_tile!(Floor);

--- a/src/game/scene.rs
+++ b/src/game/scene.rs
@@ -26,10 +26,10 @@ impl Scene {
     pub fn new() -> Scene {
         let (map, tiles) = mapgen::bsp_gen();
         return Scene {
-            player: Player::new((15, 25)),
+            player: Player::new(15, 25),
             enemies: vec![
-                Enemy::new((70, 25), 10, &map),
-                Enemy::new((50, 30), 10, &map)],
+                Enemy::new(70, 25, 10, &map),
+                Enemy::new(50, 30, 10, &map)],
             recalculate_map: true,
             map,
             tiles,
@@ -39,7 +39,7 @@ impl Scene {
     pub fn update(&mut self, key: Option<Key>) {
         let fov = if CONFIG.game.see_all { 300 } else { CONFIG.game.fov };
         if self.recalculate_map {
-            self.map.compute_fov(self.player.xy.0, self.player.xy.1, fov, true, FovAlgorithm::Basic);
+            self.map.compute_fov(self.player.x, self.player.y, fov, true, FovAlgorithm::Basic);
         }
 
         for enemy in &mut self.enemies {
@@ -59,7 +59,7 @@ impl Scene {
 
     fn draw_scene(&self, window: &Root) {
         for tile in &self.tiles {
-            let (x, y) = tile.get_xy();
+            let (x, y) = tile.get_position();
             if self.map.is_in_fov(x, y) {
                 tile.draw(window);
             }

--- a/src/game/scene.rs
+++ b/src/game/scene.rs
@@ -59,7 +59,8 @@ impl Scene {
 
     fn draw_scene(&self, window: &Root) {
         for tile in &self.tiles {
-            if self.map.is_in_fov(tile.get_x(), tile.get_y()) {
+            let (x, y) = tile.get_xy();
+            if self.map.is_in_fov(x, y) {
                 tile.draw(window);
             }
         }

--- a/src/game/scene.rs
+++ b/src/game/scene.rs
@@ -26,10 +26,10 @@ impl Scene {
     pub fn new() -> Scene {
         let (map, tiles) = mapgen::bsp_gen();
         return Scene {
-            player: Player::new(15, 25),
+            player: Player::new((15, 25)),
             enemies: vec![
-                Enemy::new(70, 25, 10, &map),
-                Enemy::new(50, 30, 10, &map)],
+                Enemy::new((70, 25), 10, &map),
+                Enemy::new((50, 30), 10, &map)],
             recalculate_map: true,
             map,
             tiles,
@@ -39,7 +39,7 @@ impl Scene {
     pub fn update(&mut self, key: Option<Key>) {
         let fov = if CONFIG.game.see_all { 300 } else { CONFIG.game.fov };
         if self.recalculate_map {
-            self.map.compute_fov(self.player.x, self.player.y, fov, true, FovAlgorithm::Basic);
+            self.map.compute_fov(self.player.xy.0, self.player.xy.1, fov, true, FovAlgorithm::Basic);
         }
 
         for enemy in &mut self.enemies {


### PR DESCRIPTION
If needed, all of these macros can be changed into ```#[derive()]``` macros. But in order to do this I believe we'd have to create another entire crate . I can look into it more if need be. Regardless, all the derive macros would act the same, they are just syntax sugar to make things shorter by a few lies so I don't think it's worth it yet.