### PR TITLE
Floor gen

### DIFF
--- a/src/game/actors/player.rs
+++ b/src/game/actors/player.rs
@@ -20,7 +20,7 @@ pub struct Player {
 impl Player {
     pub fn new(x: i32, y: i32) -> Player {
         return Player {
-            x, 
+            x,
             y,
             head: 100,
             arms: (100, 100),
@@ -66,7 +66,7 @@ impl Player {
 
     fn draw_health(&self, health: i32, label: &str, row: i32, mut window: &Root) {
         let line = format!("{:2} {: >4} ", label, health);
-        let foreground_color = 
+        let foreground_color =
             if health <= 33 {
                 colors::DARK_RED
             }

--- a/src/game/map/mapgen.rs
+++ b/src/game/map/mapgen.rs
@@ -242,7 +242,7 @@ fn generate_connecting_hallway(r1: &Room, r2: &Room) -> (Room, Room) {
     return (hallway_horizontal, hallway_vertical)
 }
 
-pub fn generate_rooms(frames: &Vec<Room>) -> Vec<Room> {
+pub fn generate_rooms(frames: &Vec<Room>) -> (Vec<Room>, (i32, i32)) {
     let rng = Rng::new_with_seed(Algo::MT, CONFIG.bsp.seed);
     let mut rooms: Vec<Room> = Vec::new();
     let mut hallways: Vec<Room> = Vec::new();
@@ -250,6 +250,8 @@ pub fn generate_rooms(frames: &Vec<Room>) -> Vec<Room> {
     let mut prev_room = 0;
     let mut curr_room = 1;
     let mut rooms_len = 0;
+
+    let mut player_spawn = (0, 0);
 
     for (i, frame) in frames.iter().enumerate() {
         let mut room_type = RoomType::Normal;
@@ -261,6 +263,10 @@ pub fn generate_rooms(frames: &Vec<Room>) -> Vec<Room> {
         }
 
         if let Some(r) = gen_room(frame, &rng, CONFIG.bsp.min_area, room_type) {
+            if i == 0 {
+                player_spawn.0 = r.x + (r.w / 2);
+                player_spawn.1 = r.y + (r.h / 2);
+            }
 
             rooms.push(r);
             rooms_len += 1;
@@ -278,7 +284,7 @@ pub fn generate_rooms(frames: &Vec<Room>) -> Vec<Room> {
     };
 
     rooms.append(&mut hallways);
-    return rooms;
+    return (rooms, player_spawn);
 }
 
 pub fn generate_frames() -> Vec<Room> {
@@ -309,16 +315,16 @@ pub fn generate_frames() -> Vec<Room> {
 }
 
 //single_room(&mut ret.0, &mut ret.1, node.x, node.y, node.w, node.h, &rng, CONFIG.bsp.frame, CONFIG.bsp.min_area);
-pub fn bsp_gen() -> (Map, Vec<Box<Tile>>) {
+pub fn bsp_gen() -> (Map, Vec<Box<Tile>>, (i32, i32)) {
     let mut map: (Map, Vec<Box<Tile>>) = empty_gen(CONFIG.game.screen_width, CONFIG.game.screen_height);
 
     let frames = generate_frames();
-    let rooms  = generate_rooms(&frames);
+    let (rooms, player_spawn) = generate_rooms(&frames);
 
     map = add_to_map(rooms, map.0, map.1);
 
     if CONFIG.bsp.frame {
         map = add_to_map(frames, map.0, map.1);
     }
-    return map;
+    return (map.0, map.1, player_spawn);
 }

--- a/src/game/map/mapgen.rs
+++ b/src/game/map/mapgen.rs
@@ -175,7 +175,7 @@ fn within_another_room(wall: (i32, i32), rooms: &Vec<Room>) -> bool {
     false
 }
 
-pub fn add_to_map(rooms: Vec<Room>, m: Map, t: Vec<Box<Tile>>) -> (Map, Vec<Box<Tile>>){
+pub fn add_to_map(rooms: Vec<Room>, m: Map, t: Vec<Box<Tile>>, first_floor: bool) -> (Map, Vec<Box<Tile>>){
     let mut map = m;
     let mut tiles = t;
 
@@ -197,7 +197,11 @@ pub fn add_to_map(rooms: Vec<Room>, m: Map, t: Vec<Box<Tile>>) -> (Map, Vec<Box<
 
         match room.room_type {
             RoomType::Normal => {},
-            RoomType::Beginning => new_up_staircase(&mut map, &mut tiles, room.x, room.y, room.w, room.h),
+            RoomType::Beginning => {
+                if !first_floor {
+                    new_up_staircase(&mut map, &mut tiles, room.x, room.y, room.w, room.h)
+                }
+            },
             RoomType::Ending => new_down_staircase(&mut map, &mut tiles, room.x, room.y, room.w, room.h)
         }
     }
@@ -242,8 +246,8 @@ fn generate_connecting_hallway(r1: &Room, r2: &Room) -> (Room, Room) {
     return (hallway_horizontal, hallway_vertical)
 }
 
-pub fn generate_rooms(frames: &Vec<Room>) -> (Vec<Room>, (i32, i32)) {
-    let rng = Rng::new_with_seed(Algo::MT, CONFIG.bsp.seed);
+pub fn generate_rooms(frames: &Vec<Room>, seed: u32) -> (Vec<Room>, (i32, i32)) {
+    let rng = Rng::new_with_seed(Algo::MT, seed);
     let mut rooms: Vec<Room> = Vec::new();
     let mut hallways: Vec<Room> = Vec::new();
 
@@ -287,9 +291,9 @@ pub fn generate_rooms(frames: &Vec<Room>) -> (Vec<Room>, (i32, i32)) {
     return (rooms, player_spawn);
 }
 
-pub fn generate_frames() -> Vec<Room> {
+pub fn generate_frames(seed: u32) -> Vec<Room> {
     let mut bsp = Bsp::new_with_size(0, 0, CONFIG.game.screen_width - 1, CONFIG.game.screen_height - 1);
-    let mut rng = Rng::new_with_seed(Algo::MT, CONFIG.bsp.seed);
+    let mut rng = Rng::new_with_seed(Algo::MT, seed);
     let mut frames: Vec<Room> = Vec::new();
     bsp.split_recursive(Some(&mut rng), CONFIG.bsp.recursion_levels,
                         CONFIG.bsp.min_horizontal_size,
@@ -315,16 +319,16 @@ pub fn generate_frames() -> Vec<Room> {
 }
 
 //single_room(&mut ret.0, &mut ret.1, node.x, node.y, node.w, node.h, &rng, CONFIG.bsp.frame, CONFIG.bsp.min_area);
-pub fn bsp_gen() -> (Map, Vec<Box<Tile>>, (i32, i32)) {
+pub fn bsp_gen(seed: u32, first_floor: bool) -> (Map, Vec<Box<Tile>>, (i32, i32)) {
     let mut map: (Map, Vec<Box<Tile>>) = empty_gen(CONFIG.game.screen_width, CONFIG.game.screen_height);
 
-    let frames = generate_frames();
-    let (rooms, player_spawn) = generate_rooms(&frames);
+    let frames = generate_frames(seed);
+    let (rooms, player_spawn) = generate_rooms(&frames, seed);
 
-    map = add_to_map(rooms, map.0, map.1);
+    map = add_to_map(rooms, map.0, map.1, first_floor);
 
     if CONFIG.bsp.frame {
-        map = add_to_map(frames, map.0, map.1);
+        map = add_to_map(frames, map.0, map.1, first_floor);
     }
     return (map.0, map.1, player_spawn);
 }

--- a/src/game/map/tile.rs
+++ b/src/game/map/tile.rs
@@ -85,3 +85,77 @@ impl Tile for Floor {
         window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
     }
 }
+
+pub struct StairUp {
+    pub x: i32,
+    pub y: i32,
+    pub walkable: bool,
+    pub see_through: bool
+}
+
+impl Tile for StairUp {
+    fn new(x: i32, y: i32) -> StairUp {
+        return StairUp{x, y, walkable: true, see_through: true};
+    }
+
+    fn get_x(&self) -> i32 {
+        return self.x;
+    }
+
+    fn get_y(&self) -> i32 {
+        return self.y;
+    }
+
+    fn get_walkable(&self) -> bool {
+        return self.walkable;
+    }
+
+    fn get_see_through(&self) -> bool {
+        return self.see_through;
+    }
+
+    fn draw(&self, mut window: &Root) {
+        window.put_char(self.x, self.y, '<', BackgroundFlag::Set);
+    }
+
+    fn clear(&self, mut window: &Root) {
+        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
+    }
+}
+
+pub struct StairDown {
+    pub x: i32,
+    pub y: i32,
+    pub walkable: bool,
+    pub see_through: bool
+}
+
+impl Tile for StairDown {
+    fn new(x: i32, y: i32) -> StairDown {
+        return StairDown{x, y, walkable: true, see_through: true};
+    }
+
+    fn get_x(&self) -> i32 {
+        return self.x;
+    }
+
+    fn get_y(&self) -> i32 {
+        return self.y;
+    }
+
+    fn get_walkable(&self) -> bool {
+        return self.walkable;
+    }
+
+    fn get_see_through(&self) -> bool {
+        return self.see_through;
+    }
+
+    fn draw(&self, mut window: &Root) {
+        window.put_char(self.x, self.y, '>', BackgroundFlag::Set);
+    }
+
+    fn clear(&self, mut window: &Root) {
+        window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
+    }
+}

--- a/src/game/map/tile.rs
+++ b/src/game/map/tile.rs
@@ -1,5 +1,10 @@
 use tcod::console::*;
 
+pub enum SceneTransitionType {
+    Up,
+    Down
+}
+
 pub trait Tile {
     fn new(x: i32, y: i32) -> Self where Self: Sized;
     fn get_x(&self) -> i32;
@@ -8,6 +13,7 @@ pub trait Tile {
     fn get_see_through(&self) -> bool;
     fn draw(&self, window: &Root);
     fn clear(&self, window: &Root);
+    fn causes_scene_transitions(&self) -> &Option<SceneTransitionType>;
 }
 
 
@@ -15,12 +21,13 @@ pub struct Wall {
     pub x: i32,
     pub y: i32,
     pub walkable: bool,
-    pub see_through: bool
+    pub see_through: bool,
+    pub causes_scene_transitions: Option<SceneTransitionType>
 }
 
 impl Tile for Wall {
     fn new(x: i32, y: i32) -> Wall {
-        return Wall{x, y, walkable: false, see_through: false};
+        return Wall{x, y, walkable: false, see_through: false, causes_scene_transitions: None};
     }
 
     fn get_x(&self) -> i32 {
@@ -46,6 +53,10 @@ impl Tile for Wall {
     fn clear(&self, mut window: &Root) {
         window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
     }
+
+    fn causes_scene_transitions(&self) -> &Option<SceneTransitionType> {
+        return &self.causes_scene_transitions;
+    }
 }
 
 
@@ -53,12 +64,13 @@ pub struct Floor {
     pub x: i32,
     pub y: i32,
     pub walkable: bool,
-    pub see_through: bool
+    pub see_through: bool,
+    pub causes_scene_transitions: Option<SceneTransitionType>
 }
 
 impl Tile for Floor {
     fn new(x: i32, y: i32) -> Floor {
-        return Floor{x, y, walkable: true, see_through: true};
+        return Floor{x, y, walkable: true, see_through: true, causes_scene_transitions: None};
     }
 
     fn get_x(&self) -> i32 {
@@ -84,18 +96,23 @@ impl Tile for Floor {
     fn clear(&self, mut window: &Root) {
         window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
     }
+
+    fn causes_scene_transitions(&self) -> &Option<SceneTransitionType> {
+        return &self.causes_scene_transitions;
+    }
 }
 
 pub struct StairUp {
     pub x: i32,
     pub y: i32,
     pub walkable: bool,
-    pub see_through: bool
+    pub see_through: bool,
+    pub causes_scene_transitions: Option<SceneTransitionType>
 }
 
 impl Tile for StairUp {
     fn new(x: i32, y: i32) -> StairUp {
-        return StairUp{x, y, walkable: true, see_through: true};
+        return StairUp{x, y, walkable: true, see_through: true, causes_scene_transitions: Some(SceneTransitionType::Up)};
     }
 
     fn get_x(&self) -> i32 {
@@ -121,18 +138,23 @@ impl Tile for StairUp {
     fn clear(&self, mut window: &Root) {
         window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
     }
+
+    fn causes_scene_transitions(&self) -> &Option<SceneTransitionType> {
+        return &self.causes_scene_transitions;
+    }
 }
 
 pub struct StairDown {
     pub x: i32,
     pub y: i32,
     pub walkable: bool,
-    pub see_through: bool
+    pub see_through: bool,
+    pub causes_scene_transitions: Option<SceneTransitionType>
 }
 
 impl Tile for StairDown {
     fn new(x: i32, y: i32) -> StairDown {
-        return StairDown{x, y, walkable: true, see_through: true};
+        return StairDown{x, y, walkable: true, see_through: true, causes_scene_transitions: Some(SceneTransitionType::Down)};
     }
 
     fn get_x(&self) -> i32 {
@@ -157,5 +179,9 @@ impl Tile for StairDown {
 
     fn clear(&self, mut window: &Root) {
         window.put_char(self.x, self.y, ' ', BackgroundFlag::Set);
+    }
+
+    fn causes_scene_transitions(&self) -> &Option<SceneTransitionType> {
+        return &self.causes_scene_transitions;
     }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -5,11 +5,16 @@ mod map;
 use tcod::input::Key;
 use tcod::console::*;
 
+use config::*;
+
 use self::scene::Scene;
+use game::map::tile::SceneTransitionType;
 
 
 pub struct Game {
-    scene: Scene
+    scenes: Vec<Scene>,
+    curr_scene_idx: usize,
+    used_seeds: Vec<u32>
 }
 
 #[derive(Debug)]
@@ -20,7 +25,9 @@ pub struct GameData {
 impl Game {
     pub fn new() -> Game {
         return Game {
-            scene: Scene::new()
+            scenes: vec![Scene::new(CONFIG.bsp.seed, true)],
+            curr_scene_idx: 0,
+            used_seeds: vec![CONFIG.bsp.seed]
         };
     }
 
@@ -38,16 +45,53 @@ impl Game {
             _ => {},
         }
 
-        self.scene.update(key);
+        match self.scenes[self.curr_scene_idx].update(key) {
+            Some(SceneTransitionType::Up) => self.scene_transition(SceneTransitionType::Up),
+            Some(SceneTransitionType::Down) => self.scene_transition(SceneTransitionType::Down),
+            None => {}
+        }
 
         return game_data;
     }
 
     pub fn draw(&self, window: &Root) {
-        self.scene.draw(window);
+        self.scenes[self.curr_scene_idx].draw(window);
     }
 
     pub fn clear(&self, window: &Root) {
-        self.scene.clear(window);
+        self.scenes[self.curr_scene_idx].clear(window);
+    }
+
+    fn scene_transition(&mut self, scene_transition_type: SceneTransitionType) {
+        match scene_transition_type {
+            SceneTransitionType::Up => self.scene_transition_up(),
+            SceneTransitionType::Down => self.scene_transition_down()
+        }
+    }
+
+    fn scene_transition_up(&mut self) {
+        if self.curr_scene_idx == 0 {
+            let seed = self.generate_unique_seed();
+            self.scenes.insert(0, Scene::new(seed, false));
+            self.used_seeds.push(seed);
+            self.curr_scene_idx = 0;
+        } else {
+            self.curr_scene_idx -= 1;
+        }
+    }
+
+    fn scene_transition_down(&mut self) {
+        if self.curr_scene_idx == self.scenes.len()-1 {
+            let seed = self.generate_unique_seed();
+            self.scenes.push(Scene::new(seed, false));
+            self.used_seeds.push(seed);
+        }
+
+        self.curr_scene_idx += 1;
+    }
+
+    fn generate_unique_seed(&self) -> u32 {
+        let seed = self.used_seeds[self.used_seeds.len()-1] + 1;
+        seed
     }
 }

--- a/src/game/scene.rs
+++ b/src/game/scene.rs
@@ -24,9 +24,9 @@ pub struct Scene {
 
 impl Scene {
     pub fn new() -> Scene {
-        let (map, tiles) = mapgen::bsp_gen();
+        let (map, tiles, player_spawn) = mapgen::bsp_gen();
         return Scene {
-            player: Player::new(15, 25),
+            player: Player::new(player_spawn.0, player_spawn.1),
             enemies: vec![
                 Enemy::new(70, 25, 10, &map),
                 Enemy::new(50, 30, 10, &map)],
@@ -68,7 +68,7 @@ impl Scene {
             health::draw_health_bar(enemy, window);
             enemy.draw(window);
         }
-        
+
         health::draw_health_bar(&self.player, window);
         self.player.draw(window);
         self.player.draw_hud(window);

--- a/src/game/scene.rs
+++ b/src/game/scene.rs
@@ -8,6 +8,7 @@ use super::actors::player::Player;
 use super::actors::enemy::Enemy;
 use game::map::mapgen;
 use game::map::tile::Tile;
+use game::map::tile::SceneTransitionType;
 use config::*;
 use game::actors::health;
 use game::actors::game_object::GameObject;
@@ -23,8 +24,8 @@ pub struct Scene {
 }
 
 impl Scene {
-    pub fn new() -> Scene {
-        let (map, tiles, player_spawn) = mapgen::bsp_gen();
+    pub fn new(seed: u32, first_floor: bool) -> Scene {
+        let (map, tiles, player_spawn) = mapgen::bsp_gen(seed, first_floor);
         return Scene {
             player: Player::new(player_spawn.0, player_spawn.1),
             enemies: vec![
@@ -36,7 +37,8 @@ impl Scene {
         };
     }
 
-    pub fn update(&mut self, key: Option<Key>) {
+    pub fn update(&mut self, key: Option<Key>) -> Option<SceneTransitionType> {
+        let mut scene_transition_type = None;
         let fov = if CONFIG.game.see_all { 300 } else { CONFIG.game.fov };
         if self.recalculate_map {
             self.map.compute_fov(self.player.x, self.player.y, fov, true, FovAlgorithm::Basic);
@@ -47,6 +49,18 @@ impl Scene {
         }
 
         self.recalculate_map = self.player.update(key, &self.tiles);
+
+        for tile in &self.tiles {
+            if self.player.get_position() == (tile.get_x(), tile.get_y()) && self.recalculate_map {
+                match tile.causes_scene_transitions() {
+                    Some(SceneTransitionType::Down) => { scene_transition_type = Some(SceneTransitionType::Down) },
+                    Some(SceneTransitionType::Up) => { scene_transition_type = Some(SceneTransitionType::Up) },
+                    None => {}
+                }
+            }
+        }
+
+        return scene_transition_type;
     }
 
     pub fn draw(&self, window: &Root) {


### PR DESCRIPTION
Pull request to resolve #26.

This has floors generating when you step on staircases. It also routes you between floors you've already generated before.

The player object doesn't carry over, but I think we can deal with that when it comes time to put state on the player that we actually care about.

Another note is that this hasn't merged in the changes from the macro branch, since those aren't in master yet.

Related to #56 -- the player is now in map flow.